### PR TITLE
mas support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ Installation steps during bootstrap can be handled in three ways:
 - `install.sh`: An installation shellscript
 - `install.homebrew`: A list of Homebrew formulas to install
 - `install.homebrew-cask`: A list of Homebrew casks to install
+- `install.mas`: A list of App Store apps to install
 - `install.open`: A list of files to be handled by the default application association using the `open` command
+
+#### Installing from the App Store with `install.mas` files ####
+
+Applications from the App Store are referenced by a numeric id rather than a name.
+In order to find out the id you can use the command `mas search <term>`.
+Entries in `install.mas` should be in the format `<id> <name>` (the same format as the results of `mas search`).
 
 ### Plugins ###
 

--- a/lib/installers.zsh
+++ b/lib/installers.zsh
@@ -2,6 +2,7 @@
 libdir=${0:a:h}
 source $libdir/terminal.zsh
 source $libdir/homebrew.zsh
+source $libdir/mas.zsh
 source $libdir/git.zsh
 
 function link_files() {
@@ -165,12 +166,15 @@ function main() {
     wait
     brew_upgrade_formulas
     brew_install_formulas
+    mas_upgrade_formulas
+    mas_install_formulas
     run_postinstall
   else
     info 'installing dotfiles'
     dotfiles_install
     run_installers
     brew_install_formulas
+    mas_install_formulas
     run_postinstall
     create_localrc
   fi

--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -5,7 +5,7 @@ function mas_install_formulas() {
   for file in `dotfiles_find install.mas`; do
     while read formula; do
       mas_install $formula
-    done<$file
+    done < <(grep ^ $file)
   done
 }
 

--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -1,18 +1,23 @@
 mas_installed=""
 
 function mas_install_formulas() {
-  mas_installed=$(mas list 2> /dev/null)
-  for file in `dotfiles_find install.mas`; do
-    while read formula; do
-      mas_install $formula
-    done < <(grep ^ $file)
-  done
+  mas_files=`dotfiles_find install.mas`
+  if [ -n "$mas_files" ]; then
+    mas_installed=$(mas list 2> /dev/null)
+    for file in $mas_files; do
+      while read formula; do
+        mas_install $formula
+      done < <(grep ^ $file)
+    done
+  fi
 }
 
 function mas_upgrade_formulas() {
-  outdated=$(mas outdated 2> /dev/null | cut -d ' ' -f2- | cut -d '(' -f1 | sed -e 's/ *$//' | sed -e :a -e '$!N; s/\n/, /; ta')
-  if [ -n "$outdated" ]; then
-    run "upgrading apps ($outdated)" "mas upgrade"
+  if test $(which mas); then
+    outdated=$(mas outdated 2> /dev/null | cut -d ' ' -f2- | cut -d '(' -f1 | sed -e 's/ *$//' | sed -e :a -e '$!N; s/\n/, /; ta')
+    if [ -n "$outdated" ]; then
+      run "upgrading apps ($outdated)" "mas upgrade"
+    fi
   fi
 }
 

--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -1,0 +1,49 @@
+mas_installed=""
+
+function mas_install_formulas() {
+  mas_installed=$(mas list 2> /dev/null)
+  for file in `dotfiles_find install.mas`; do
+    while read formula; do
+      mas_install $formula
+    done<$file
+  done
+}
+
+function mas_upgrade_formulas() {
+  mas outdated 2> /dev/null | while read formula; do
+    no_version="${formula% *}"
+    id="${no_version%% *}"
+    name="${no_version#* }"
+    run "upgrading mas ($name)" "mas upgrade $id"
+  done
+}
+
+function mas_install() {
+  mas_check_and_install
+  id="${1%% *}"
+  name="${1#* }"
+  if ! echo $mas_installed | grep -q "^$id"; then
+    if mas install $id > /dev/null 2>&1; then
+      success "installed $name"
+    else
+      fail "failed to install $name"
+    fi
+  fi
+}
+
+function mas_check_and_install() {
+  if ! test $(which mas); then
+    info "mas is not installed, installing"
+    brew_check_and_install
+    brew_install mas
+    user "enter Apple id"
+    read -r appleid
+    user "enter Apple password"
+    read -rs applepwd
+    if mas signin $appleid $applepwd > /dev/null 2>&1; then
+      success "signed into App Store as $appleid"
+    else
+      fail "failed to sign in to App Store as $appleid"
+    fi
+  fi
+}

--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -14,7 +14,7 @@ function mas_upgrade_formulas() {
     no_version="${formula% *}"
     id="${no_version%% *}"
     name="${no_version#* }"
-    run "upgrading mas ($name)" "mas upgrade $id"
+    run "upgrading $name" "mas upgrade $id"
   done
 }
 

--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -10,12 +10,10 @@ function mas_install_formulas() {
 }
 
 function mas_upgrade_formulas() {
-  mas outdated 2> /dev/null | while read formula; do
-    no_version="${formula% *}"
-    id="${no_version%% *}"
-    name="${no_version#* }"
-    run "upgrading $name" "mas upgrade $id"
-  done
+  outdated=$(mas outdated 2> /dev/null | cut -d ' ' -f2- | cut -d '(' -f1 | sed -e 's/ *$//' | sed -e :a -e '$!N; s/\n/, /; ta')
+  if [ -n "$outdated" ]; then
+    run "upgrading apps ($outdated)" "mas upgrade"
+  fi
 }
 
 function mas_install() {

--- a/oh-your.zshrc
+++ b/oh-your.zshrc
@@ -67,7 +67,7 @@ DISABLE_AUTO_UPDATE="true"
 DEFAULT_USER=$(whoami)
 
 # configure theme(s)
-ZSH_THEME="agnoster"
+ZSH_THEME="powerlevel9k/powerlevel9k"
 
 # configure plugins
 plugins=("${(@f)$(


### PR DESCRIPTION
`install.mas` files would contain content such as 

```
803453959 Slack
443987910 1Password
1176895641 Spark
```

The commands `mas list` and `mas outdated` return the same format but with version numbers appended. The `mas install` command takes just the numeric id.

It would be nice to be able to install apps by name but unfortunately `mas search` doesn't have a way to search for an exact term and even if the search term is an exact match to an app name you may get > 1 result.