### PR TITLE
list outdated brews as comma separated

### DIFF
--- a/lib/homebrew.zsh
+++ b/lib/homebrew.zsh
@@ -40,7 +40,7 @@ function brew_install() {
 
 function brew_upgrade() {
   brew="brew $1"
-  outdated=$(eval $brew outdated)
+  outdated=$(eval $brew outdated | sed -e :a -e '$!N; s/\n/, /; ta')
   if [ -n "$outdated" ]; then
     run "upgrading homebrew $1 ($outdated)" "$brew upgrade"
     run "cleaning up homebrew $1" "$brew cleanup"


### PR DESCRIPTION
`$outdated` is newline separated so it appears like that in the text echoed to console. e.g.

```
  [ .. ] upgrading homebrew  (mas
bash
node)
```

This converts it into a comma separated string, e.g.

```
  [ .. ] upgrading homebrew  (mas, bash, node)
```