### PR TITLE
Deal with irritating habit of Mac App Store apps having 'names' like 'Evernote – stay organized'

### DIFF
--- a/lib/mas.zsh
+++ b/lib/mas.zsh
@@ -14,7 +14,7 @@ function mas_install_formulas() {
 
 function mas_upgrade_formulas() {
   if test $(which mas); then
-    outdated=$(mas outdated 2> /dev/null | cut -d ' ' -f2- | cut -d '(' -f1 | sed -e 's/ *$//' | sed -e :a -e '$!N; s/\n/, /; ta')
+    outdated=$(mas outdated 2> /dev/null | cut -d ' ' -f2- | cut -d '(' -f1 | cut -d– -f1 | cut -d- -f1 | sed -e 's/ *$//' | sed -e :a -e '$!N; s/\n/, /; ta')
     if [ -n "$outdated" ]; then
       run "upgrading apps ($outdated)" "mas upgrade"
     fi


### PR DESCRIPTION
I'm just trimming out the suffix when listing the names of apps being updated.